### PR TITLE
Fix properties breaking admin alignment in Django3

### DIFF
--- a/nested_inline/static/admin/css/forms-nested.css
+++ b/nested_inline/static/admin/css/forms-nested.css
@@ -64,7 +64,6 @@ form ul.inline li {
     display: block;
     padding: 3px 10px 0 0;
     float: left;
-    width: 8em;
 }
 
 .aligned ul label {
@@ -75,11 +74,6 @@ form ul.inline li {
 
 .colMS .aligned .vLargeTextField, .colMS .aligned .vXMLLargeTextField {
     width: 350px;
-}
-
-form .aligned p, form .aligned ul {
-    margin-left: 7em;
-    padding-left: 30px;
 }
 
 form .aligned table p {
@@ -160,7 +154,6 @@ fieldset.monospace textarea {
     padding: 5px 7px;
     text-align: right;
     background-color: white;
-    border: 1px solid #ccc;
     margin: 5px 0;
     overflow: hidden;
 }


### PR DESCRIPTION
Django3 somewhat changed it's css styling. That resulted in collision with django-nested-inline which ended up overloading a bunch of variables in Django admin css files. That resulted in an unaligned admin page and other styling errors.